### PR TITLE
Fix busy waiting and remove Windows-only code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [WINDOWS] Kraepelin-Pauli Test Exercise
+# Kraepelin-Pauli Test Exercise
 
 This is a simple program designed to help you train your addition skills for Kraepelin or Pauli test. It generates random addition problems and prompts you for the correct answer. The program provides immediate feedback on your responses and keeps track of your score.
 
@@ -12,7 +12,6 @@ This is a simple program designed to help you train your addition skills for Kra
 ## Prerequisites
 
 - Python 3.x
-- Windows OS
 
 ## Getting Started
 
@@ -23,7 +22,7 @@ This is a simple program designed to help you train your addition skills for Kra
 
 2. Navigate to the project directory:
    ```shell
-   cd Addition-Skills-Training
+   cd Windows_Kraepelin-Pauli-Test-Exercise
 
 3. Run the program:
    ```shell

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
+"""Kraepelin/Pauli test training application."""
+
 import random
 import time
-import msvcrt
 
 def generate_question():
     num1 = random.randint(0, 9)
@@ -9,12 +10,8 @@ def generate_question():
     return num1, num2, result
 
 def get_user_input():
-    user_input = ''
-    while msvcrt.kbhit():
-        char = msvcrt.getch()
-        if char.isdigit():
-            user_input += char.decode()
-    return user_input
+    """Return the digits entered by the user."""
+    return input().strip()
 
 def main():
     score = 0
@@ -24,12 +21,7 @@ def main():
         print(f"What is {num1} + {num2}?")
 
         start_time = time.time()
-
-        while True:
-            user_input = get_user_input()
-            if user_input:
-                break
-
+        user_input = get_user_input()
         end_time = time.time()
 
         elapsed_time = end_time - start_time


### PR DESCRIPTION
## Summary
- remove `msvcrt` dependency and use standard `input`
- update README to use the correct directory name and drop Windows-specific notice

## Testing
- `python -m py_compile main.py`
- `printf '5\n' | python main.py`

------
https://chatgpt.com/codex/tasks/task_b_684ce9646888832f82eaa42d9764eecd